### PR TITLE
fixed state managemnt of mitm listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Inspired by Yan Cui's articles on latency injection for AWS Lambda (https://hack
 ### 2020-02-17 v0.2.0
 
 * Added blacklist failure.
-* Updated example application to retrive file from S3 based on URL from DynamoDB.
+* Updated example application to store file in S3 and item in DynamoDB.
 
 ### 2020-02-13 v0.1.1
 

--- a/lib/failure.js
+++ b/lib/failure.js
@@ -45,10 +45,6 @@ async function getConfig () {
 var injectFailure = function (fn) {
   return async function () {
     try {
-      if (mitm == null) {
-        mitm = Mitm()
-      }
-      mitm.disable()
 
       let config = await getConfig()
       if (config.isEnabled === true && Math.random() < config.rate) {
@@ -69,15 +65,13 @@ var injectFailure = function (fn) {
           childProcess.spawnSync('dd', ['if=/dev/zero', 'of=/tmp/diskspace-failure-' + Date.now() + '.tmp', 'count=1000', 'bs=' + config.diskSpace * 1000])
         } else if (config.failureMode === 'denylist') {
           console.log('Injecting dependency failure through a network block for denylisted sites: ' + config.denylist)
-        
-          if ('connect' in mitm._events) {
-            while (typeof(mitm._events.connect) != 'function') {
-              mitm.removeListener('connect', mitm._events.connect[0])
-            }
-            mitm.removeListener('connect', mitm._events.connect)
+       
+          // if the global mitm doesn't yet exist, create it now
+          if (mitm == null) {
+            mitm = Mitm()
           }
-          mitm.enable()
 
+          // attach a handler to filter the configured deny patterns
           let blRegexs = []
           config.denylist.forEach(function (regexStr) {
             blRegexs.push(new RegExp(regexStr))
@@ -96,6 +90,11 @@ var injectFailure = function (fn) {
               socket.bypass()
             }
           })
+
+          // remove any previously attached handlers, leaving only the most recently added
+          while (typeof(mitm._events.connect) != 'function') {
+            mitm.removeListener('connect', mitm._events.connect[0])
+          }
         }
       }
       return fn.apply(this, arguments)

--- a/lib/failure.js
+++ b/lib/failure.js
@@ -1,119 +1,137 @@
-'use strict'
-const aws = require('aws-sdk')
-const ssm = new aws.SSM()
-const fetch = require('node-fetch')
-const childProcess = require('child_process')
-const Mitm = require('mitm')
+"use strict";
+const aws = require("aws-sdk");
+const ssm = new aws.SSM();
+const fetch = require("node-fetch");
+const childProcess = require("child_process");
+const Mitm = require("mitm");
 
-var mitm = null
+var mitm = null;
 
-function clearMitm () {
-    if (mitm != null) {
-        mitm.disable ()
-    }
+function clearMitm() {
+  if (mitm != null) {
+    mitm.disable();
+  }
 }
 
-async function getConfig () {
+async function getConfig() {
   const defaults = {
-    isEnabled: false
-  }
+    isEnabled: false,
+  };
   if (process.env.FAILURE_APPCONFIG_CONFIGURATION) {
     try {
       if (process.env.AWS_APPCONFIG_EXTENSION_HTTP_PORT) {
-        var appconfigPort = process.env.AWS_APPCONFIG_EXTENSION_HTTP_PORT
+        var appconfigPort = process.env.AWS_APPCONFIG_EXTENSION_HTTP_PORT;
       } else {
-        var appconfigPort = 2772
+        var appconfigPort = 2772;
       }
-      const url = 'http://localhost:' + appconfigPort + '/applications/' + process.env.FAILURE_APPCONFIG_APPLICATION + '/environments/' + process.env.FAILURE_APPCONFIG_ENVIRONMENT + '/configurations/' + process.env.FAILURE_APPCONFIG_CONFIGURATION
-      const response = await fetch(url)
-      const json = await response.json()
-      return json
+      const url =
+        "http://localhost:" +
+        appconfigPort +
+        "/applications/" +
+        process.env.FAILURE_APPCONFIG_APPLICATION +
+        "/environments/" +
+        process.env.FAILURE_APPCONFIG_ENVIRONMENT +
+        "/configurations/" +
+        process.env.FAILURE_APPCONFIG_CONFIGURATION;
+      const response = await fetch(url);
+      const json = await response.json();
+      return json;
     } catch (err) {
-      console.error(err)
-      return defaults
+      console.error(err);
+      return defaults;
     }
   } else if (process.env.FAILURE_INJECTION_PARAM) {
     try {
       let params = {
-        Name: process.env.FAILURE_INJECTION_PARAM
-      }
-      let response = await ssm.getParameter(params).promise()
-      let json = JSON.parse(response.Parameter.Value)
-      return json
+        Name: process.env.FAILURE_INJECTION_PARAM,
+      };
+      let response = await ssm.getParameter(params).promise();
+      let json = JSON.parse(response.Parameter.Value);
+      return json;
     } catch (err) {
-      console.error(err)
-      return defaults
+      console.error(err);
+      return defaults;
     }
   } else {
-    return defaults
+    return defaults;
   }
 }
 var injectFailure = function (fn) {
   return async function () {
     try {
-      let config = await getConfig()
+      let config = await getConfig();
 
-      if (config.isEnabled === false || config.failureMode != 'denylist') {
-          clearMitm ()
+      if (config.isEnabled === false || config.failureMode != "denylist") {
+        clearMitm();
       }
 
       if (config.isEnabled === true && Math.random() < config.rate) {
-        if (config.failureMode === 'latency') {
-          let latencyRange = config.maxLatency - config.minLatency
-          let setLatency = Math.floor(config.minLatency + Math.random() * latencyRange)
-          console.log('Injecting ' + setLatency + ' ms latency.')
-          await new Promise(resolve => setTimeout(resolve, setLatency))
-        } else if (config.failureMode === 'exception') {
-          console.log('Injecting exception message: ' + config.exceptionMsg)
-          throw new Error(config.exceptionMsg)
-        } else if (config.failureMode === 'statuscode') {
-          console.log('Injecting status code: ' + config.statusCode)
-          let response = { statusCode: config.statusCode }
-          return response
-        } else if (config.failureMode === 'diskspace') {
-          console.log('Injecting disk space: ' + config.diskSpace + ' MB')
-          childProcess.spawnSync('dd', ['if=/dev/zero', 'of=/tmp/diskspace-failure-' + Date.now() + '.tmp', 'count=1000', 'bs=' + config.diskSpace * 1000])
-        } else if (config.failureMode === 'denylist') {
-          console.log('Injecting dependency failure through a network block for denylisted sites: ' + config.denylist)
+        if (config.failureMode === "latency") {
+          let latencyRange = config.maxLatency - config.minLatency;
+          let setLatency = Math.floor(
+            config.minLatency + Math.random() * latencyRange
+          );
+          console.log("Injecting " + setLatency + " ms latency.");
+          await new Promise((resolve) => setTimeout(resolve, setLatency));
+        } else if (config.failureMode === "exception") {
+          console.log("Injecting exception message: " + config.exceptionMsg);
+          throw new Error(config.exceptionMsg);
+        } else if (config.failureMode === "statuscode") {
+          console.log("Injecting status code: " + config.statusCode);
+          let response = { statusCode: config.statusCode };
+          return response;
+        } else if (config.failureMode === "diskspace") {
+          console.log("Injecting disk space: " + config.diskSpace + " MB");
+          childProcess.spawnSync("dd", [
+            "if=/dev/zero",
+            "of=/tmp/diskspace-failure-" + Date.now() + ".tmp",
+            "count=1000",
+            "bs=" + config.diskSpace * 1000,
+          ]);
+        } else if (config.failureMode === "denylist") {
+          console.log(
+            "Injecting dependency failure through a network block for denylisted sites: " +
+              config.denylist
+          );
 
           // if the global mitm doesn't yet exist, create it now
           if (mitm == null) {
-            mitm = Mitm()
+            mitm = Mitm();
           }
-            mitm.enable ()
+          mitm.enable();
 
           // attach a handler to filter the configured deny patterns
-          let blRegexs = []
+          let blRegexs = [];
           config.denylist.forEach(function (regexStr) {
-            blRegexs.push(new RegExp(regexStr))
-          })
-          mitm.on('connect', function (socket, opts) {
-            let block = false
+            blRegexs.push(new RegExp(regexStr));
+          });
+          mitm.on("connect", function (socket, opts) {
+            let block = false;
             blRegexs.forEach(function (blRegex) {
               if (blRegex.test(opts.host)) {
-                console.log('Intercepted network connection to ' + opts.host)
-                block = true
+                console.log("Intercepted network connection to " + opts.host);
+                block = true;
               }
-            })
+            });
             if (block) {
-              socket.end()
+              socket.end();
             } else {
-              socket.bypass()
+              socket.bypass();
             }
-          })
+          });
 
           // remove any previously attached handlers, leaving only the most recently added
-          while (typeof(mitm._events.connect) != 'function') {
-            mitm.removeListener('connect', mitm._events.connect[0])
+          while (typeof mitm._events.connect != "function") {
+            mitm.removeListener("connect", mitm._events.connect[0]);
           }
         }
       }
-      return fn.apply(this, arguments)
+      return fn.apply(this, arguments);
     } catch (ex) {
-      console.log(ex)
-      throw ex
+      console.log(ex);
+      throw ex;
     }
-  }
-}
+  };
+};
 
-module.exports = injectFailure
+module.exports = injectFailure;

--- a/lib/failure.js
+++ b/lib/failure.js
@@ -5,6 +5,8 @@ const fetch = require('node-fetch')
 const childProcess = require('child_process')
 const Mitm = require('mitm')
 
+var mitm = null
+
 async function getConfig () {
   const defaults = {
     isEnabled: false
@@ -43,6 +45,11 @@ async function getConfig () {
 var injectFailure = function (fn) {
   return async function () {
     try {
+      if (mitm == null) {
+        mitm = Mitm()
+      }
+      mitm.disable()
+
       let config = await getConfig()
       if (config.isEnabled === true && Math.random() < config.rate) {
         if (config.failureMode === 'latency') {
@@ -62,7 +69,15 @@ var injectFailure = function (fn) {
           childProcess.spawnSync('dd', ['if=/dev/zero', 'of=/tmp/diskspace-failure-' + Date.now() + '.tmp', 'count=1000', 'bs=' + config.diskSpace * 1000])
         } else if (config.failureMode === 'denylist') {
           console.log('Injecting dependency failure through a network block for denylisted sites: ' + config.denylist)
-          let mitm = Mitm()
+        
+          if ('connect' in mitm._events) {
+            while (typeof(mitm._events.connect) != 'function') {
+              mitm.removeListener('connect', mitm._events.connect[0])
+            }
+            mitm.removeListener('connect', mitm._events.connect)
+          }
+          mitm.enable()
+
           let blRegexs = []
           config.denylist.forEach(function (regexStr) {
             blRegexs.push(new RegExp(regexStr))

--- a/lib/failure.js
+++ b/lib/failure.js
@@ -7,6 +7,12 @@ const Mitm = require('mitm')
 
 var mitm = null
 
+function clearMitm () {
+    if (mitm != null) {
+        mitm.disable ()
+    }
+}
+
 async function getConfig () {
   const defaults = {
     isEnabled: false
@@ -45,8 +51,12 @@ async function getConfig () {
 var injectFailure = function (fn) {
   return async function () {
     try {
-
       let config = await getConfig()
+
+      if (config.isEnabled === false || config.failureMode != 'denylist') {
+          clearMitm ()
+      }
+
       if (config.isEnabled === true && Math.random() < config.rate) {
         if (config.failureMode === 'latency') {
           let latencyRange = config.maxLatency - config.minLatency
@@ -65,11 +75,12 @@ var injectFailure = function (fn) {
           childProcess.spawnSync('dd', ['if=/dev/zero', 'of=/tmp/diskspace-failure-' + Date.now() + '.tmp', 'count=1000', 'bs=' + config.diskSpace * 1000])
         } else if (config.failureMode === 'denylist') {
           console.log('Injecting dependency failure through a network block for denylisted sites: ' + config.denylist)
-       
+
           // if the global mitm doesn't yet exist, create it now
           if (mitm == null) {
             mitm = Mitm()
           }
+            mitm.enable ()
 
           // attach a handler to filter the configured deny patterns
           let blRegexs = []


### PR DESCRIPTION
this is a fix for #16 - it puts the mitm object (collection of EventEmitter listeners) in the library global namespace so that it persists across function invocations.  this lets failure-lambda manage the number of listeners registered by the library.